### PR TITLE
Add more problem types during annotation

### DIFF
--- a/index/schema.json
+++ b/index/schema.json
@@ -33,7 +33,7 @@
 						"type": "array",
 						"items": {
 							"type": "string",
-							"pattern": "^(noise|multiple languages|wrong language|excess loan words|language or place reference)$"
+							"pattern": "^(noise|multiple languages|wrong language|excess loan words|language or place reference|pauses)$"
 						}
 					},
 					"genders": {

--- a/index/schema.json
+++ b/index/schema.json
@@ -33,7 +33,7 @@
 						"type": "array",
 						"items": {
 							"type": "string",
-							"pattern": "^(noise|multiple languages|wrong language|excess loan words)$"
+							"pattern": "^(noise|multiple languages|wrong language|excess loan words|language or place reference)$"
 						}
 					},
 					"genders": {

--- a/src/annotate.py
+++ b/src/annotate.py
@@ -23,9 +23,9 @@ import ui
 
 Segment = namedtuple('Segment', 'sample offset duration')
 
-GUIDELINE_VERSION = 1
+GUIDELINE_VERSION = 2
 GUIDELINES = """
-ANNOTATION GUIDELINES v1
+ANNOTATION GUIDELINES v2
 
 You are about to listen to a number of audio clips in different languages.
 For each clip, we want to work out if it's suitable to use as a sample of
@@ -49,6 +49,11 @@ excess loan words?
         Mark with a "y" if many of the words are borrowed from English, making
         the sample not a good representation of the language. Use your own
         judgement here.
+
+language or place reference?
+        Samples that mention the name of their language or a distinctive place
+        that the language is from may be inappropriate in the use of language
+        guessing games. If an obvious reference is there, mark "y".
 
 speakers
         Count the number of different people you hear speaking in the clip.
@@ -313,7 +318,8 @@ class AnnotateCmd(cmd.Cmd):
             problems = ui.input_multi_options(
                 'Problems with the sample',
                 ['noise', 'wrong language',
-                 'multiple languages', 'excess loan words'],
+                 'multiple languages', 'excess loan words',
+                 'language or country reference'],
             )
             speakers = ui.input_number('speakers', minimum=1, maximum=10)
             genders = ui.input_single_option(

--- a/src/annotate.py
+++ b/src/annotate.py
@@ -55,6 +55,9 @@ language or place reference?
         that the language is from may be inappropriate in the use of language
         guessing games. If an obvious reference is there, mark "y".
 
+pauses?
+        Are there long pauses which eat up much of the clip? If so, mark "y".
+
 speakers
         Count the number of different people you hear speaking in the clip.
         Normally it will just be one or two.
@@ -319,7 +322,7 @@ class AnnotateCmd(cmd.Cmd):
                 'Problems with the sample',
                 ['noise', 'wrong language',
                  'multiple languages', 'excess loan words',
-                 'language or country reference'],
+                 'language or place reference', 'pauses'],
             )
             speakers = ui.input_number('speakers', minimum=1, maximum=10)
             genders = ui.input_single_option(


### PR DESCRIPTION
Add the problem types `pauses`, for when there are long pauses in the sample, and `language or place reference`, for when a language or prominent place in a linguistic community is clearly mentioned.